### PR TITLE
move currentSchemaVersion out of MonadStore

### DIFF
--- a/src/Ananke/Backend/JSON.hs
+++ b/src/Ananke/Backend/JSON.hs
@@ -95,4 +95,3 @@ instance MonadStore JSON where
   getCountOfKeyId kid   = gets   $ AppState.getCountOfKeyId kid
   createTable           = undefined
   migrate         _   _ = undefined
-  currentSchemaVersion  = undefined

--- a/src/Ananke/Backend/SQLite.hs
+++ b/src/Ananke/Backend/SQLite.hs
@@ -71,4 +71,3 @@ instance MonadStore SQLite where
   getCountOfKeyId kid     = withDatabase $ \db -> Database.getCountOfKeyId db kid
   createTable             = withDatabase $ \db -> Database.createTable     db
   migrate         sv  kid = withDatabase $ \db -> Database.migrate         db sv  kid
-  currentSchemaVersion    = return Database.currentSchemaVersion

--- a/src/Ananke/Backend/SQLite/Database.hs
+++ b/src/Ananke/Backend/SQLite/Database.hs
@@ -9,7 +9,6 @@ module Ananke.Backend.SQLite.Database
   , getCount
   , getCountOfKeyId
   , addKeyId
-  , currentSchemaVersion
   , createTable
   , migrate
   ) where
@@ -29,9 +28,6 @@ rethrowLift :: (MonadThrow m, MonadIO m) => IO a -> m a
 rethrowLift a = liftIO $ Exception.catch a f
   where
     f = throwM . Database . T.unpack . SQLite3.sqlErrorDetails
-
-currentSchemaVersion :: SchemaVersion
-currentSchemaVersion = MkSchemaVersion 2
 
 executeStatement :: SQLite3.Statement -> IO ()
 executeStatement stmt = SQLite3.stepNoCB stmt >>= \case

--- a/src/Ananke/Interfaces.hs
+++ b/src/Ananke/Interfaces.hs
@@ -154,4 +154,3 @@ class Monad m => MonadStore m where
   getCountOfKeyId      :: KeyId -> m Int
   createTable          :: m ()
   migrate              :: SchemaVersion -> KeyId -> m ()
-  currentSchemaVersion :: m SchemaVersion


### PR DESCRIPTION
After some consideration, I've decided that it's probably a mistake to have schema version numbers depend on which backend is used.  What this means in practice is that a schema version change may not affect all backends, in which case an unaffected backend's migration will be a no-op.