### PR TITLE
move setup code into Backend modules

### DIFF
--- a/ananke.cabal
+++ b/ananke.cabal
@@ -41,6 +41,7 @@ executable ananke
 
 library
   exposed-modules:     Ananke
+                     , Ananke.Backend
                      , Ananke.Backend.SQLite
                      , Ananke.Backend.SQLite.AppContext
                      , Ananke.Backend.SQLite.Database

--- a/src/Ananke.hs
+++ b/src/Ananke.hs
@@ -39,7 +39,7 @@ handleResponse res = case res of
 runSQLiteApp :: SQLite.AppContext -> IO ExitCode
 runSQLiteApp ctx = do
   cmd <- Parser.runCLIParser
-  Exception.catch (SQLite.run (Evaluator.setup >> Evaluator.eval cmd) ctx >>= handleResponse)
+  Exception.catch (SQLite.run (SQLite.setup >> Evaluator.eval cmd) ctx >>= handleResponse)
                   handleError
 
 #ifdef BACKEND_JSON

--- a/src/Ananke/Backend.hs
+++ b/src/Ananke/Backend.hs
@@ -1,0 +1,24 @@
+module Ananke.Backend
+  ( currentSchemaVersion
+  , createSchemaFile
+  , getSchemaVersion
+  ) where
+
+import           Ananke.Data
+import           Ananke.Interfaces
+
+currentSchemaVersion :: SchemaVersion
+currentSchemaVersion = MkSchemaVersion 2
+
+getSchemaVersionFromFile :: MonadInteraction m => FilePath -> m SchemaVersion
+getSchemaVersionFromFile path = MkSchemaVersion . read <$> readFileAsString path
+
+createSchemaFile :: MonadInteraction m => FilePath -> SchemaVersion -> m SchemaVersion
+createSchemaFile path version = writeFileFromString path (show version) >> return version
+
+getSchemaVersion :: (MonadInteraction m, MonadStore m) => FilePath -> m SchemaVersion
+getSchemaVersion path = do
+  fileExists <- doesFileExist path
+  if fileExists
+    then getSchemaVersionFromFile path
+    else createSchemaFile path currentSchemaVersion

--- a/src/Ananke/Backend/JSON.hs
+++ b/src/Ananke/Backend/JSON.hs
@@ -87,11 +87,9 @@ instance MonadConfigReader JSON where
   askConfig = ask
 
 instance MonadStore JSON where
-  put             e     = modify $ AppState.put             e
-  delete          e     = modify $ AppState.delete          e
-  runQuery        q     = gets   $ AppState.runQuery        q
-  selectAll             = gets     AppState.selectAll
-  getCount              = gets     AppState.getCount
-  getCountOfKeyId kid   = gets   $ AppState.getCountOfKeyId kid
-  createTable           = undefined
-  migrate         _   _ = undefined
+  put             e = modify $ AppState.put             e
+  delete          e = modify $ AppState.delete          e
+  runQuery        q = gets   $ AppState.runQuery        q
+  selectAll         = gets     AppState.selectAll
+  getCount          = gets     AppState.getCount
+  getCountOfKeyId k = gets   $ AppState.getCountOfKeyId k

--- a/src/Ananke/Interfaces.hs
+++ b/src/Ananke/Interfaces.hs
@@ -146,11 +146,9 @@ instance MonadInteraction m => MonadInteraction (StateT s m)  where
 -- * MonadStore
 
 class Monad m => MonadStore m where
-  put                  :: Entry -> m ()
-  delete               :: Entry -> m ()
-  runQuery             :: Query -> m [Entry]
-  selectAll            :: m [Entry]
-  getCount             :: m Int
-  getCountOfKeyId      :: KeyId -> m Int
-  createTable          :: m ()
-  migrate              :: SchemaVersion -> KeyId -> m ()
+  put             :: Entry -> m ()
+  delete          :: Entry -> m ()
+  runQuery        :: Query -> m [Entry]
+  selectAll       :: m [Entry]
+  getCount        :: m Int
+  getCountOfKeyId :: KeyId -> m Int

--- a/tests/Ananke/Properties.hs
+++ b/tests/Ananke/Properties.hs
@@ -17,7 +17,6 @@ import           Ananke.Backend.SQLite   (AppContext (..))
 import qualified Ananke.Backend.SQLite   as SQLite
 import qualified Ananke.Configuration    as Configuration
 import           Ananke.Data
-import qualified Ananke.Evaluator        as Evaluator
 import           Ananke.Interfaces
 import           Ananke.Orphans          ()
 
@@ -78,7 +77,7 @@ doProperties = do
   let preConfig = MkPreConfig (First (Just dir)) mempty mempty mempty
   _          <- Directory.copyFile "./example/ananke.conf" (dir ++ "/ananke.conf")
   ctx        <- Configuration.configureWith preConfig >>= SQLite.initialize
-  _          <- SQLite.run Evaluator.setup ctx
+  _          <- SQLite.run SQLite.setup ctx
   results    <- mapM (\p -> QuickCheck.quickCheckWithResult QuickCheck.stdArgs (p ctx)) tests
   _          <- SQLite3.close (appContextDatabase ctx)
   return results


### PR DESCRIPTION
We are no longer re-encrypting all entries after an sqlite migration, because re-encryption can only happen at the evaluation phase of execution.  Future work will update the check machinery to ensure that the proper check is performed after a migration.